### PR TITLE
Add uppercase/lowercase modifiers

### DIFF
--- a/js/tracery/modifiers.js
+++ b/js/tracery/modifiers.js
@@ -42,6 +42,15 @@ define([], function() {'use strict';
 
         },
 
+        uppercase : function(s) {
+            return s.toUpperCase();
+        },
+
+        lowercase : function(s) {
+            return s.toLowerCase();
+
+        },
+
         inQuotes : function(s) {
             return '"' + s + '"';
         },

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,8 @@ story : ["This is a story about #mainCharacter#"]
 ```
 
 Expansion symbols can have modifiers.  Modifiers can change something about the string expansion of that symbol.
- `#animal.capitalize#` or `#animal.a#` or `#animal.s#`
+ `#animal.capitalize#` `#animal.capitalizeAll#` or `#animal.a#` or `#animal.s#` or `#animal.uppercase#` or `#animal.lowercase#`
+
 ```
 name: ["Brittany"],
 animal: ["wombat"],

--- a/tracery.js
+++ b/tracery.js
@@ -1,7 +1,7 @@
 /**
 * @author Kate Compton
 */
-     
+
 var tracery = {
     utilities : {}
 };
@@ -557,6 +557,15 @@ var tracery = {
 
         capitalize : function(s) {
             return s.charAt(0).toUpperCase() + s.slice(1);
+
+        },
+
+        uppercase : function(s) {
+            return s.toUpperCase();
+        },
+
+        lowercase : function(s) {
+            return s.toLowerCase();
 
         },
 
@@ -1220,4 +1229,4 @@ var tracery = {
 
     };
 
-})(); 
+})();


### PR DESCRIPTION
Resolves #24.

Let me know if you'd prefer `upper`/`lower` or something else.

Also, I edited both js/tracery/modifiers.js and tracery.js. Does only one need editing?
