### PR TITLE
simplify isVowel()

### DIFF
--- a/js/tracery/mods-eng-basic.js
+++ b/js/tracery/mods-eng-basic.js
@@ -3,8 +3,7 @@
  */
 
 function isVowel(c) {
-	var c2 = c.toLowerCase();
-	return (c2 === 'a') || (c2 === 'e') || (c2 === 'i') || (c2 === 'o') || (c2 === 'u');
+	return (c === 'a') || (c === 'e') || (c === 'i') || (c === 'o') || (c === 'u') || (c === 'A') || (c === 'E') || (c === 'I') || (c === 'O') || (c === 'U');
 };
 
 function isAlphaNum(c) {


### PR DESCRIPTION
The bruteforce vowel check, if it's a performance choice, can be 10x improved by skipping
- assignment of a new variable
- the surprising overhead of a complicated function like toLowerCase

Check out a comparison of vowel checkers here:
https://jsperf.com/isvowel